### PR TITLE
feat: disable notifications to github when publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ cache:
 notifications:
   email: false
 node_js:
-  - '9'
+  - '10'
   - '8'
-  - '6'
-  - '4'
 after_success:
   - npm run travis-deploy-once "npm run semantic-release"
 branches:

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "devDependencies": {
     "semantic-release": "^15.4.1",
     "travis-deploy-once": "^5.0.0"
+  },
+  "release": {
+    "success": []
   }
 }


### PR DESCRIPTION
semantic-release writes comments to all PRs and issues included in a
release. This is nice, but perhaps a bit too noisy